### PR TITLE
Script updates to support latest Debian Stretch version for c.g.c doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ condor-master condor-compute condor-submit:
 	   gcloud compute  instances create  $@-template \
 	     --zone=us-east1-b \
 	     --machine-type=n1-standard-1 \
-	     --image=debian-9-stretch-v20180820 \
+	     --image=debian-9-stretch-v20210122 \
 	     --image-project=debian-cloud \
 	     --boot-disk-size=10GB \
 	     --metadata-from-file startup-script=startup-scripts/$@.sh ; \

--- a/startup-scripts/condor-compute.sh
+++ b/startup-scripts/condor-compute.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 #
-apt-get update && apt-get install -y wget curl net-tools vm python-pandas python-numpy
+apt-get update && apt-get install -y wget curl net-tools vm python-pandas python-numpy apt-transport-https
 echo "deb http://research.cs.wisc.edu/htcondor/debian/stable/ jessie contrib" >> /etc/apt/sources.list
 wget -qO - http://research.cs.wisc.edu/htcondor/debian/HTCondor-Release.gpg.key | apt-key add -
 apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y condor=8.4.11~dfsg.1-1

--- a/startup-scripts/condor-master.sh
+++ b/startup-scripts/condor-master.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apt-get update && apt-get install -y wget curl net-tools vm
+apt-get update && apt-get install -y wget curl net-tools vm apt-transport-https
 echo "deb http://research.cs.wisc.edu/htcondor/debian/stable/ jessie contrib" >> /etc/apt/sources.list
 wget -qO - http://research.cs.wisc.edu/htcondor/debian/HTCondor-Release.gpg.key | apt-key add -
 apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y condor=8.4.11~dfsg.1-1

--- a/startup-scripts/condor-submit.sh
+++ b/startup-scripts/condor-submit.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 #
-apt-get update && apt-get install -y wget curl net-tools vm python-pandas python-numpy
+apt-get update && apt-get install -y wget curl net-tools vm python-pandas python-numpy apt-transport-https
 echo "deb http://research.cs.wisc.edu/htcondor/debian/stable/ jessie contrib" >> /etc/apt/sources.list
 wget -qO - http://research.cs.wisc.edu/htcondor/debian/HTCondor-Release.gpg.key | apt-key add -
 apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y condor=8.4.11~dfsg.1-1


### PR DESCRIPTION
These updates are required for the associated doc at https://cloud.google.com/solutions/analyzing-portfolio-risk-using-htcondor-and-compute-engine to work correctly.

The Debian image used in the Makefile is rather old and should be updated to a more recent Stretch image.

The `condor-*` startup scripts also look to be missing `apt-transport-https` packages to successfully install and configure the required components.